### PR TITLE
Ubuntu 20.04 does not support legacy curses linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-FLAGS = -g -Wall -Wextra -pedantic -lcursesw
+FLAGS = -g -Wall -Wextra -pedantic -lncursesw
 
 TARGET = snake
 


### PR DESCRIPTION
Should the legacy linking against `libcurses` be finally just left to link against `libncurses`?